### PR TITLE
Add configurable API URLs

### DIFF
--- a/MMM-DeepSpaceSignals.js
+++ b/MMM-DeepSpaceSignals.js
@@ -6,6 +6,11 @@ Module.register("MMM-DeepSpaceSignals", {
       gravitational: true,
       pulsar: false
     },
+    apiUrls: {
+      frb: "https://chimefrb-open-data-api.naic.edu/frb",
+      gravitational: "https://example.com/ligo/api",
+      pulsar: "https://pulsar.example.com/api"
+    },
     minStrength: {
       frb: null,
       gravitational: null,

--- a/README.md
+++ b/README.md
@@ -27,6 +27,11 @@ Add the module to the `modules` array in `config.js`:
       gravitational: true,
       pulsar: false
     },
+    apiUrls: {
+      frb: "https://chimefrb-open-data-api.naic.edu/frb",
+      gravitational: "https://example.com/ligo/api",
+      pulsar: "https://pulsar.example.com/api"
+    },
     minStrength: {
       frb: null,
       gravitational: null,
@@ -42,8 +47,8 @@ The helper polls a few public APIs:
 - **LIGO/Virgo** – gravitational wave alerts
 - **ATNF Pulsar Database** – pulsar observations
 
-The URLs in the code are placeholders and should be replaced with real API
-endpoints before use.
+The default URLs shown above are placeholders. Replace them with the real API
+endpoints for your setup in the `apiUrls` section of the module configuration.
 
 ## License
 MIT

--- a/node_helper.js
+++ b/node_helper.js
@@ -42,7 +42,7 @@ module.exports = NodeHelper.create({
 
   async fetchFRB() {
     try {
-      const url = "https://chimefrb-open-data-api.naic.edu/frb"; // placeholder
+      const url = this.config.apiUrls?.frb || "";
       const res = await fetch(url);
       const data = await res.json();
       return data.slice(0, 5).map(item => ({
@@ -60,7 +60,7 @@ module.exports = NodeHelper.create({
 
   async fetchGravitational() {
     try {
-      const url = "https://example.com/ligo/api"; // placeholder
+      const url = this.config.apiUrls?.gravitational || "";
       const res = await fetch(url);
       const data = await res.json();
       return data.events.map(ev => ({
@@ -78,7 +78,7 @@ module.exports = NodeHelper.create({
 
   async fetchPulsar() {
     try {
-      const url = "https://pulsar.example.com/api"; // placeholder
+      const url = this.config.apiUrls?.pulsar || "";
       const res = await fetch(url);
       const text = await res.text();
       const json = await parseStringPromise(text);


### PR DESCRIPTION
## Summary
- add `apiUrls` section to default config
- use `apiUrls` in helper functions
- document new setting in README

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68607f715f8c8324beccf407a354fe77