### PR TITLE
Fix gravitational API parsing

### DIFF
--- a/node_helper.js
+++ b/node_helper.js
@@ -63,7 +63,7 @@ module.exports = NodeHelper.create({
       const url = this.config.apiUrls?.gravitational || "";
       const res = await fetch(url);
       const data = await res.json();
-      return data.events.map(ev => ({
+      return Object.values(data.events || {}).map(ev => ({
         type: "GW",
         time: ev.time,
         intensity: ev.significance,


### PR DESCRIPTION
## Summary
- handle the GW API events list when it is an object instead of an array

## Testing
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6860d302c70c83248222f3d6767397bb