### PR TITLE
Handle non-JSON FRB responses gracefully

### DIFF
--- a/node_helper.js
+++ b/node_helper.js
@@ -49,7 +49,18 @@ module.exports = NodeHelper.create({
     try {
       const url = this.config.apiUrls?.frb || "";
       const res = await fetch(url);
-      const data = await res.json();
+      if (!res.ok) {
+        console.error("[DSS helper] FRB fetch HTTP", res.status);
+        return [];
+      }
+      const text = await res.text();
+      let data;
+      try {
+        data = JSON.parse(text);
+      } catch (err) {
+        console.error("[DSS helper] FRB response not JSON", err);
+        return [];
+      }
       const items = data.events || data || [];
       const result = items.slice(0, 5).map(item => ({
         type: "FRB",


### PR DESCRIPTION
## Summary
- improve error handling for Fast Radio Burst API

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6860d91a3c748324bd2629ab4823c38c