### PR TITLE
Fix FRB URL and parsing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+package-lock.json

--- a/MMM-DeepSpaceSignals.js
+++ b/MMM-DeepSpaceSignals.js
@@ -7,7 +7,7 @@ Module.register("MMM-DeepSpaceSignals", {
       pulsar: false
     },
     apiUrls: {
-      frb: "https://chime-frb-open-data.github.io/voevents.json",
+      frb: "https://raw.githubusercontent.com/chime-frb-open-data/voevents/main/voevents.json",
       gravitational: "https://gwosc.org/api/v2/events",
       pulsar: "" // hanteras via Python
     },

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Add the module to the `modules` array in `config.js`:
       pulsar: false
     },
     apiUrls: {
-      frb: "https://chimefrb-open-data-api.naic.edu/frb",
+      frb: "https://raw.githubusercontent.com/chime-frb-open-data/voevents/main/voevents.json",
       gravitational: "https://example.com/ligo/api",
       pulsar: "https://pulsar.example.com/api"
     },
@@ -54,7 +54,8 @@ The repository also includes a small Python helper script used for querying the
 ATNF database directly. If you plan to run it, install `psrqpy` and `astropy`
 and execute `pulsar_fetcher.py` manually or from a cron job.
 
-The default URLs shown above are placeholders. Replace them with the real API
+The default URLs shown above are examples. The FRB URL points to the CHIME/FRB
+open data JSON file, while the others should be replaced with the appropriate
 endpoints for your setup in the `apiUrls` section of the module configuration.
 
 ## License

--- a/node_helper.js
+++ b/node_helper.js
@@ -61,12 +61,13 @@ module.exports = NodeHelper.create({
         console.error("[DSS helper] FRB response not JSON", err);
         return [];
       }
-      const items = data.events || data || [];
-      const result = items.slice(0, 5).map(item => ({
+      const items = data.events || data.voevents || data || [];
+      const arr = Array.isArray(items) ? items : Object.values(items);
+      const result = arr.slice(0, 5).map(item => ({
         type: "FRB",
-        time: item.date || item.detected || "",
-        intensity: item.fluence || item.signal || "",
-        url: item.url || "",
+        time: item.time || item.date || item.detected || item.datetime || "",
+        intensity: item.fluence || item.signal || item.snr || "",
+        url: item.url || item.voevent || item.link || "",
         level: "red"
       }));
       console.log('[DSS helper] FRB events fetched', result.length);


### PR DESCRIPTION
## Summary
- fix FRB default API URL
- map FRB fields to match CHIME open data
- note correct FRB URL in README
- add `.gitignore`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6860e24ba26883249b42a08a85e44037