### PR TITLE
Fix FRB default url

### DIFF
--- a/MMM-DeepSpaceSignals.js
+++ b/MMM-DeepSpaceSignals.js
@@ -7,7 +7,7 @@ Module.register("MMM-DeepSpaceSignals", {
       pulsar: false
     },
     apiUrls: {
-      frb: "https://raw.githubusercontent.com/chime-frb-open-data/voevents/main/voevents.json",
+      frb: "https://chime-frb-open-data.github.io/voevents/voevents.json",
       gravitational: "https://gwosc.org/api/v2/events",
       pulsar: "" // hanteras via Python
     },

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Add the module to the `modules` array in `config.js`:
       pulsar: false
     },
     apiUrls: {
-      frb: "https://raw.githubusercontent.com/chime-frb-open-data/voevents/main/voevents.json",
+      frb: "https://chime-frb-open-data.github.io/voevents/voevents.json",
       gravitational: "https://example.com/ligo/api",
       pulsar: "https://pulsar.example.com/api"
     },


### PR DESCRIPTION
## Summary
- update the default CHIME/FRB API url in the module configuration
- keep README in sync with the new URL

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6860f23f12ec832489098239ecd3f740