### PR TITLE
Reduce APOD image width

### DIFF
--- a/MMM-DeepSpaceSignals.css
+++ b/MMM-DeepSpaceSignals.css
@@ -47,7 +47,7 @@
   text-decoration: underline;
 }
 .dss-apod-image {
-  max-width: 100%;
+  max-width: 200px;
   height: auto;
   display: block;
   margin: 4px 0;

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ The helper polls a few public APIs:
 - **CHIME/FRB** – recent Fast Radio Burst detections
 - **LIGO/Virgo** – gravitational wave alerts
 - **ATNF Pulsar Database** – pulsar observations
- - **NASA APOD** – daily astronomy image and description. When enabled, the module displays the APOD image and its explanation directly in the table if the media type is an image.
+- **NASA APOD** – daily astronomy image and description. When enabled, the module displays the APOD image and its explanation directly in the table if the media type is an image. The image is constrained to a maximum width of 200&nbsp;px so it remains small within the module.
 
 The repository also includes a small Python helper script used for querying the
 ATNF database directly. If you plan to run it, install `psrqpy` and `astropy`


### PR DESCRIPTION
## Summary
- keep the Astronomy Picture of the Day images small
- document the smaller APOD image size in the README

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6861a881302083248b0a32f57f24661e