### PR TITLE
Allow offline FRB notice to show

### DIFF
--- a/node_helper.js
+++ b/node_helper.js
@@ -33,8 +33,7 @@ module.exports = NodeHelper.create({
       if (!ev || !ev.type) return false;
       if (!ev.time || ev.time === 'No time') return false;
       if (!ev.intensity || ev.intensity === 'No intensity') return false;
-      if (ev.level === 'grey') return false;
-      return true;
+      return true; // keep offline events (level "grey")
     });
   },
 


### PR DESCRIPTION
## Summary
- keep grey 'offline' events when filtering fetched data so the mirror shows a warning when an FRB endpoint fails

## Testing
- `npm install`


------
https://chatgpt.com/codex/tasks/task_e_6861bf4806188324bd20674b45c87483