### PR TITLE
Fix APOD caption and add scrolling

### DIFF
--- a/MMM-DeepSpaceSignals.css
+++ b/MMM-DeepSpaceSignals.css
@@ -41,9 +41,24 @@
   border-radius: 4px;
 }
 
+.dss-apod-caption-wrapper {
+  overflow: hidden;
+  position: relative;
+}
+
 .dss-apod-caption {
   margin-top: 6px;
   font-size: 12px;
   font-style: italic;
   color: #ccc;
+  white-space: pre-wrap;
+}
+
+.dss-apod-caption.scrolling {
+  animation: dss-scroll 20s linear infinite alternate;
+}
+
+@keyframes dss-scroll {
+  from { transform: translateY(0); }
+  to { transform: translateY(calc(-1 * var(--scroll-distance))); }
 }

--- a/MMM-DeepSpaceSignals.js
+++ b/MMM-DeepSpaceSignals.js
@@ -109,10 +109,25 @@ Module.register("MMM-DeepSpaceSignals", {
       apodContainer.appendChild(img);
 
       if (this.apod.explanation) {
+        const captionWrapper = document.createElement("div");
+        captionWrapper.className = "dss-apod-caption-wrapper";
+
         const caption = document.createElement("div");
         caption.className = "dss-apod-caption";
         caption.innerText = this.apod.explanation;
-        apodContainer.appendChild(caption);
+        captionWrapper.appendChild(caption);
+        apodContainer.appendChild(captionWrapper);
+
+        window.setTimeout(() => {
+          const lineHeight = parseFloat(window.getComputedStyle(caption).lineHeight) || 16;
+          const maxHeight = lineHeight * 10;
+          captionWrapper.style.maxHeight = maxHeight + "px";
+          if (caption.scrollHeight > maxHeight) {
+            const scrollAmount = caption.scrollHeight - maxHeight;
+            caption.style.setProperty("--scroll-distance", scrollAmount + "px");
+            caption.classList.add("scrolling");
+          }
+        }, 100);
       }
 
       wrapper.appendChild(apodContainer);

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ The helper polls the following public APIs:
 | **ATNF Pulsars**| Pulsar observations (JSON or script)| ❌ / Optional    |
 | **NASA APOD**   | Daily astronomy image + caption     | ✅ Yes (free)    |
 
-> When enabled, the module displays the APOD image and its explanation directly in the table if the media type is an image. The image is constrained to a maximum width of 200 px to fit nicely inside the module.
+> When enabled, the module displays the APOD image and its explanation directly in the table if the media type is an image. The image is constrained to a maximum width of 200 px to fit nicely inside the module. If the caption is longer than 10 lines it appears in a scrollable box that slowly moves every 20&nbsp;seconds.
 
 If the primary FRB endpoint is unreachable (e.g., 404 error), the module
 tries the `frbBackup` URL. If that also fails, it loads the local file

--- a/node_helper.js
+++ b/node_helper.js
@@ -246,15 +246,15 @@ module.exports = NodeHelper.create({
         return [];
       }
 
-      const result = [{
-        type: "APOD",
-        time: data.date,
-        intensity: data.title || "",
-        url: data.url || data.hdurl || "",
-        level: "blue",
-        media_type: data.media_type,
-        description: data.explanation || ""
-      }];
+        const result = [{
+          type: "APOD",
+          time: data.date,
+          intensity: data.title || "",
+          url: data.url || data.hdurl || "",
+          level: "blue",
+          media_type: data.media_type,
+          explanation: data.explanation || ""
+        }];
 
       console.log('[DSS helper] APOD fetched', result.length);
       return result;


### PR DESCRIPTION
## Summary
- fix mismatch between helper and front-end for APOD explanation
- show APOD caption inside scrolling wrapper when text is long
- style scrolling caption and add animation
- document scrolling behaviour in README

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6861c574f2608324afd458994b57dd34