### PR TITLE
Fix APOD caption scroll direction and speed

### DIFF
--- a/MMM-DeepSpaceSignals.css
+++ b/MMM-DeepSpaceSignals.css
@@ -55,10 +55,10 @@
 }
 
 .dss-apod-caption.scrolling {
-  animation: dss-scroll 20s linear infinite alternate;
+  animation: dss-scroll 40s linear infinite alternate;
 }
 
 @keyframes dss-scroll {
-  from { transform: translateY(0); }
-  to { transform: translateY(calc(-1 * var(--scroll-distance))); }
+  from { transform: translateY(calc(-1 * var(--scroll-distance))); }
+  to { transform: translateY(0); }
 }

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ The helper polls the following public APIs:
 | **ATNF Pulsars**| Pulsar observations (JSON or script)| ❌ / Optional    |
 | **NASA APOD**   | Daily astronomy image + caption     | ✅ Yes (free)    |
 
-> When enabled, the module displays the APOD image and its explanation directly in the table if the media type is an image. The image is constrained to a maximum width of 200 px to fit nicely inside the module. If the caption is longer than 10 lines it appears in a scrollable box that slowly moves every 20&nbsp;seconds.
+> When enabled, the module displays the APOD image and its explanation directly in the table if the media type is an image. The image is constrained to a maximum width of 200 px to fit nicely inside the module. If the caption is longer than 10 lines it appears in a scrollable box that slowly moves every 40&nbsp;seconds.
 
 If the primary FRB endpoint is unreachable (e.g., 404 error), the module
 tries the `frbBackup` URL. If that also fails, it loads the local file


### PR DESCRIPTION
## Summary
- slow down the APOD caption scrolling and reverse its direction
- document the slower 40s scroll speed in the README

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6861c7d7b27083249e46fa296c2b1aff