### PR TITLE
Fix caption scroll direction

### DIFF
--- a/MMM-DeepSpaceSignals.css
+++ b/MMM-DeepSpaceSignals.css
@@ -55,11 +55,11 @@
 }
 
 .dss-apod-caption.scrolling {
-  /* Scroll from top to bottom and restart without bouncing */
+  /* Scroll from bottom to top and restart without bouncing */
   animation: dss-scroll 40s linear infinite;
 }
 
 @keyframes dss-scroll {
-  from { transform: translateY(calc(-1 * var(--scroll-distance))); }
-  to { transform: translateY(0); }
+  from { transform: translateY(0); }
+  to { transform: translateY(calc(-1 * var(--scroll-distance))); }
 }


### PR DESCRIPTION
## Summary
- fix the APOD caption's scroll animation to move from bottom to top

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6862167222608324a12d94cd801b4f1f