### PR TITLE
Remove event links from mirror display

### DIFF
--- a/MMM-DeepSpaceSignals.js
+++ b/MMM-DeepSpaceSignals.js
@@ -54,7 +54,7 @@ Module.register("MMM-DeepSpaceSignals", {
     const thead = document.createElement("thead");
     const headerRow = document.createElement("tr");
 
-    ["Type", "Time", "Intensity", "Link"].forEach(text => {
+    ["Type", "Time", "Intensity"].forEach(text => {
       const th = document.createElement("th");
       th.innerText = text;
       headerRow.appendChild(th);
@@ -81,15 +81,6 @@ Module.register("MMM-DeepSpaceSignals", {
       strengthCell.innerText = event.intensity !== null ? event.intensity : "";
       row.appendChild(strengthCell);
 
-      const linkCell = document.createElement("td");
-      if (event.url) {
-        const a = document.createElement("a");
-        a.href = event.url;
-        a.innerText = "🔗";
-        a.target = "_blank";
-        linkCell.appendChild(a);
-      }
-      row.appendChild(linkCell);
 
       tbody.appendChild(row);
     });


### PR DESCRIPTION
## Summary
- remove `Link` column from UI table to avoid clickable links on the mirror

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686229247d008324914d2745cfe66e9b