### PR TITLE
Implement FRB fluence color levels

### DIFF
--- a/MMM-DeepSpaceSignals.css
+++ b/MMM-DeepSpaceSignals.css
@@ -23,12 +23,24 @@
   background-color: rgba(255, 0, 0, 0.2);
 }
 
+.dss-row.orange {
+  background-color: rgba(255, 165, 0, 0.2);
+}
+
 .dss-row.yellow {
   background-color: rgba(255, 255, 0, 0.2);
 }
 
 .dss-row.green {
   background-color: rgba(0, 255, 0, 0.2);
+}
+
+.dss-row.blue {
+  background-color: rgba(0, 0, 255, 0.2);
+}
+
+.dss-row.grey {
+  background-color: rgba(128, 128, 128, 0.2);
 }
 
 .dss-apod {

--- a/node_helper.js
+++ b/node_helper.js
@@ -109,13 +109,24 @@ module.exports = NodeHelper.create({
 
         const arr = Array.isArray(items) ? items : Object.values(items);
 
-        const result = arr.slice(0, 5).map(item => ({
-          type: "FRB",
-          time: item.time || item.date || item.detected || item.datetime || "",
-          intensity: item.fluence || item.signal || item.snr || "",
-          url: item.url || item.voevent || item.link || "",
-          level: "red"
-        }));
+        const result = arr.slice(0, 5).map(item => {
+          const fluence = parseFloat(item.fluence);
+          let level = "grey";
+          if (!isNaN(fluence)) {
+            if (fluence > 100) level = "red";
+            else if (fluence > 20) level = "orange";
+            else if (fluence >= 5) level = "yellow";
+            else if (fluence >= 1) level = "green";
+            else level = "blue";
+          }
+          return {
+            type: "FRB",
+            time: item.time || item.date || item.detected || item.datetime || "",
+            intensity: item.fluence || item.signal || item.snr || "",
+            url: item.url || item.voevent || item.link || "",
+            level
+          };
+        });
 
         console.log('[DSS helper] FRB events fetched', result.length);
         return result;
@@ -271,13 +282,24 @@ module.exports = NodeHelper.create({
       const raw = fs.readFileSync(file, 'utf8');
       const json = JSON.parse(raw);
       const arr = Array.isArray(json) ? json : (json.events || []);
-      return arr.map(item => ({
-        type: 'FRB',
-        time: item.time || item.date || '',
-        intensity: item.fluence || item.signal || '',
-        url: item.url || '',
-        level: 'grey'
-      }));
+      return arr.map(item => {
+        const fluence = parseFloat(item.fluence);
+        let level = 'grey';
+        if (!isNaN(fluence)) {
+          if (fluence > 100) level = 'red';
+          else if (fluence > 20) level = 'orange';
+          else if (fluence >= 5) level = 'yellow';
+          else if (fluence >= 1) level = 'green';
+          else level = 'blue';
+        }
+        return {
+          type: 'FRB',
+          time: item.time || item.date || '',
+          intensity: item.fluence || item.signal || '',
+          url: item.url || '',
+          level
+        };
+      });
     } catch (err) {
       console.error('[DSS helper] Failed to load local FRB sample', err);
       return [{


### PR DESCRIPTION
## Summary
- classify FRB events by fluence and set `level` field accordingly
- color code sample FRB data the same way
- style rows for new `blue`, `orange`, and `grey` levels

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_68622d2cd65c83248fbdef1fc5b05f2a