### PR TITLE
Color-code intensity numbers

### DIFF
--- a/MMM-DeepSpaceSignals.css
+++ b/MMM-DeepSpaceSignals.css
@@ -19,28 +19,28 @@
   text-align: left;
 }
 
-.dss-row.red {
-  background-color: rgba(255, 0, 0, 0.2);
+.dss-row.red td:nth-child(3) {
+  color: #ff4040;
 }
 
-.dss-row.orange {
-  background-color: rgba(255, 165, 0, 0.2);
+.dss-row.orange td:nth-child(3) {
+  color: #ff8800;
 }
 
-.dss-row.yellow {
-  background-color: rgba(255, 255, 0, 0.2);
+.dss-row.yellow td:nth-child(3) {
+  color: #cccc00;
 }
 
-.dss-row.green {
-  background-color: rgba(0, 255, 0, 0.2);
+.dss-row.green td:nth-child(3) {
+  color: #00cc00;
 }
 
-.dss-row.blue {
-  background-color: rgba(0, 0, 255, 0.2);
+.dss-row.blue td:nth-child(3) {
+  color: #4d4dff;
 }
 
-.dss-row.grey {
-  background-color: rgba(128, 128, 128, 0.2);
+.dss-row.grey td:nth-child(3) {
+  color: #808080;
 }
 
 .dss-apod {

--- a/README.md
+++ b/README.md
@@ -77,10 +77,22 @@ Add the module to the `modules` array in `config.js`:
 }
 ```
 
-`intensity` values depend on the data source:  
-- FRB events use **fluence (Jy·ms)**  
-- Gravitational waves show **significance**  
+`intensity` values depend on the data source:
+- FRB events use **fluence (Jy·ms)**
+- Gravitational waves show **significance**
 - Pulsars may report **signal-to-noise ratio (SNR)**
+
+### Intensity Levels
+
+The value in the **Intensity** column is color‑coded to make reading the table easier:
+
+| Fluence (Jy·ms) | Interpretation | Notes |
+|-------------------|---------------|-------|
+| <span style="color:#4d4dff;">&lt; 1</span> | Very weak | Hard to detect, may be near background noise |
+| <span style="color:#00cc00;">1 – 5</span> | Weak to moderate | Common range for many typical FRBs |
+| <span style="color:#cccc00;">5 – 20</span> | Moderate to strong | Likely detectable with medium-sized radio arrays |
+| <span style="color:#ff8800;">&gt; 20</span> | Strong or rare | May indicate nearby or unusually energetic source |
+| <span style="color:#ff4040;">&gt; 100</span> | Extremely strong (rare) | Often referred to as "giant bursts" or hyperflares |
 
 ---
 


### PR DESCRIPTION
## Summary
- color-code intensity numbers instead of table rows
- document intensity levels in README

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6862309c1dfc832499f5a299611e1a3b