### PR TITLE
Add Python pulsar script integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,14 +32,18 @@ npm install
 ## 🐍 Optional: Python Pulsar Support (ATNF Fetcher)
 
 If the optional Python dependencies are installed, the Node helper will run
-`pulsar_fetcher.py` automatically the first time it needs a local `pulsars.json`
-file. Install the required packages, for example on Raspberry Pi:
+`pulsar_fetcher.py` automatically the first time it needs a local
+`pulsars.json` file. You can also point `apiUrls.pulsar` directly to a Python
+script (e.g. `fetch_pulsars.py`). If the URL ends with `.py`, the helper
+executes the script and expects JSON on stdout. Install the required packages,
+for example on Raspberry Pi:
 
 ```bash
 pip install psrqpy astropy --break-system-packages
 ```
 
-The script queries the ATNF catalogue and writes the results to `pulsars.json`.
+The example scripts query the ATNF catalogue and either write the results to
+`pulsars.json` or output JSON directly.
 
 ---
 
@@ -64,7 +68,7 @@ Add the module to the `modules` array in `config.js`:
       frb: "data/frb_sample.json",
       frbBackup: null,
       gravitational: "https://gwosc.org/eventapi/jsonfull/allevents/",
-      pulsar: "pulsars.json",
+      pulsar: "fetch_pulsars.py",
       apod: "https://api.nasa.gov/planetary/apod?api_key=*****"
     },
     minStrength: {

--- a/fetch_pulsars.py
+++ b/fetch_pulsars.py
@@ -1,0 +1,30 @@
+from psrqpy import QueryATNF
+import json
+import sys
+
+
+def fetch_last_5_pulsars():
+    query = QueryATNF()
+    table = query.table
+
+    if 'PEPOCH' in table.colnames:
+        mask = ~table['PEPOCH'].mask if hasattr(table['PEPOCH'], 'mask') else [True] * len(table['PEPOCH'])
+        filtered = table[mask]
+        sorted_table = filtered[filtered.argsort('PEPOCH')[::-1]]
+    else:
+        sorted_table = table
+
+    pulsars = []
+    for row in sorted_table[:5]:
+        pulsars.append({
+            'PSRJ': row['PSRJ'] if 'PSRJ' in table.colnames else 'N/A',
+            'P0': row['P0'] if 'P0' in table.colnames else None,
+            'DM': row['DM'] if 'DM' in table.colnames else None,
+            'time': str(row['PEPOCH']) if 'PEPOCH' in table.colnames else ''
+        })
+    return pulsars
+
+
+if __name__ == '__main__':
+    data = fetch_last_5_pulsars()
+    json.dump(data, sys.stdout)


### PR DESCRIPTION
## Summary
- add `fetch_pulsars.py` to retrieve the five most recent pulsars
- allow node helper to execute a `.py` script for pulsars
- document Python script support in README

## Testing
- `node -v`
- `python3 fetch_pulsars.py`

------
https://chatgpt.com/codex/tasks/task_e_6863a0edbf708324b9097d68b9799421