### PR TITLE
Fix pulsar fetcher output path

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,10 +33,11 @@ npm install
 
 If the optional Python dependencies are installed, the Node helper will run
 `pulsar_fetcher.py` automatically the first time it needs a local
-`pulsars.json` file. You can also point `apiUrls.pulsar` directly to a Python
-script (e.g. `fetch_pulsars.py`). If the URL ends with `.py`, the helper
-executes the script and expects JSON on stdout. Install the required packages,
-for example on Raspberry Pi:
+`pulsars.json` file. The script now writes this file to the module directory so
+the helper can load it without needing a specific working directory. You can
+also point `apiUrls.pulsar` directly to a Python script (e.g. `fetch_pulsars.py`).
+If the URL ends with `.py`, the helper executes the script and expects JSON on
+stdout. Install the required packages, for example on Raspberry Pi:
 
 ```bash
 pip install psrqpy astropy --break-system-packages

--- a/pulsar_fetcher.py
+++ b/pulsar_fetcher.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import os
 from psrqpy import QueryATNF
 
 def main():
@@ -20,7 +21,8 @@ def main():
         })
 
     logging.info("[DSS py] writing %d pulsars to file", len(pulsars))
-    with open("modules/MMM-DeepSpaceSignals/pulsars.json", "w") as f:
+    out_path = os.path.join(os.path.dirname(__file__), "pulsars.json")
+    with open(out_path, "w") as f:
         json.dump(pulsars, f)
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- write `pulsars.json` to the module directory in `pulsar_fetcher.py`
- document new behaviour in README

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6863adf165908324a6933d7ffed60c9f